### PR TITLE
fix: 💫 output caption lines with a more balanced length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,10 +252,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "utf8parse"
@@ -263,6 +292,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "nom",
+ "textwrap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ description = "Lint Web Video Text Tracks Format (WebVTT) files"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.3", features = ["derive"] }
 nom = { version = "7.1.3", features = ["alloc"] }
+textwrap = "0.16.0"

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,21 +1,45 @@
-use crate::parser::{div_ceiling, parse_cue_payload_text, parse_header_value};
+use crate::parser::{parse_cue_payload_text, parse_header_value};
 
 #[test]
-pub fn test_div_ceiling() {
-    assert_eq!(div_ceiling(8, 3), 3);
-    assert_eq!(div_ceiling(6, 2), 3);
-}
-
-#[test]
-pub fn test_parse_cue_payload_text() {
+pub fn test_parse_cue_payload_text_sticks_to_max_width_where_possible() {
     // arrange
-    let line = "Sample cue text.";
+    let line = "So, these are the people who actually work at the organization. You've got a name for each of them.";
+
+    // act
+    let result = parse_cue_payload_text(line);
 
     // assert
     assert_eq!(
-        parse_cue_payload_text(line),
-        Ok(("", vec!["Sample cue text."]))
+        result,
+        vec![
+            "So, these are the people who actually work",
+            "at the organization. You've got a name for",
+            "each of them."
+        ]
     );
+    assert_eq!(result.len(), 3);
+    assert!(result.iter().all(|val| val.len() <= 42));
+}
+
+#[test]
+pub fn test_parse_cue_payload_text_stretches_max_width_where_needed() {
+    // arrange
+    let line = "So, these are the people who actually work at the organization. For each of them, we have a name, as well as a job role and email.";
+
+    // act
+    let result = parse_cue_payload_text(line);
+
+    // assert
+    assert_eq!(
+        result,
+        vec![
+            "So, these are the people who actually work at",
+            "the organization. For each of them, we have a",
+            "name, as well as a job role and email."
+        ]
+    );
+    assert_eq!(result.len(), 3);
+    assert!(result.iter().all(|val| val.len() <= 45));
 }
 
 #[test]


### PR DESCRIPTION
# Description

The algorithm for splitting the caption paylod is quite crude, and often results in uneven line length in the generated captions.  On top, width is sometimes wider than the limit even when the text can fit within the limit on three lines.

To remedy these issues we add the textwrap crate which reads ahead as it splits text, to optimise for even line length.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] cargo test run with all tests passing
- [X] add news tests to document expected behavior for long lines

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
